### PR TITLE
Setup of available tests using cmake utility ctest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,9 +9,13 @@ ENABLE_LANGUAGE(Fortran)
 SET(CMAKE_Fortran_MODULE_DIRECTORY "${CALYPSO_BINARY_DIR}/include")
 SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CALYPSO_BINARY_DIR}/bin")
 SET(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CALYPSO_BINARY_DIR}/lib")
-
 # Use the preprocessor to handle #ifdefs
 ADD_DEFINITIONS(-cpp)
+
+IF(EXISTS ${CMAKE_SOURCE_DIR}/tests/CMakeLists.txt)
+  ENABLE_TESTING()
+  ADD_SUBDIRECTORY(tests)
+ENDIF()
 
 # Look for MPI and add the required flags if found
 FIND_PACKAGE(MPI)

--- a/src/programs/data_utilities/CMakeLists.txt
+++ b/src/programs/data_utilities/CMakeLists.txt
@@ -18,3 +18,6 @@ SET(MOD_SPH_INITIAL INITIAL_FIELD/main_sph_initial_fld.f90 INITIAL_FIELD/SPH_ana
 ADD_EXECUTABLE(sph_initial_field ${MOD_SPH_INITIAL})
 TARGET_LINK_LIBRARIES(sph_initial_field calypso fftpack.5d)
 
+SET(SPH_ENE_CHECK_SRC_FILES TIME_HISTORIES/compare_sph_mean_square.f90)
+ADD_EXECUTABLE(sph_ene_check ${SPH_ENE_CHECK_SRC_FILES})
+TARGET_LINK_LIBRARIES(sph_ene_check calypso fftpack.5d)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,50 @@
+# A function that extracts from file control_MHD
+# the number of MPI processes this test is to be invoked as.
+# This is encoded in .prm files through lines of the form
+#    'num_subdomain_ctl            4'
+# The result is returned in a variable _mpi_count in the
+# caller's scope.
+FUNCTION(get_mpi_count _filename)
+  FILE(STRINGS ${_filename} _input_lines
+       REGEX "^ * num_subdomain_ctl")
+#  MESSAGE( STATUS "Read line is: " ${_input_lines} )
+  IF("${_input_lines}" STREQUAL "")
+    SET(_mpi_count 1 PARENT_SCOPE)
+  ELSE()
+    # go over the (possibly multiple) lines with MPI markers and choose the last
+    FOREACH(_input_line ${_input_lines})
+     SET(_last_line ${_input_line})
+    ENDFOREACH()
+    STRING(REGEX REPLACE "^ *num_subdomain_ctl *([0-9]+) *$" "\\1"
+           _mpi_count ${_last_line})
+#    MESSAGE( STATUS "MPI_count: " ${_mpi_count} )
+    SET(_mpi_count "${_mpi_count}" PARENT_SCOPE)
+  ENDIF()
+ENDFUNCTION()
+# A function that extracts from file control_MHD
+# the number of openMP threads this test is to be invoked with.
+# This is encoded in control_MHD files through lines of the form
+#    'num_smp_ctl    2'
+# The result is returned in a variable _mpi_count in the
+# caller's scope.
+FUNCTION(get_openmp_count _filename)
+  FILE(STRINGS ${_filename} _input_lines
+       REGEX "^ * num_smp_ctl")
+#  MESSAGE( STATUS "Read line is: " ${_input_lines} )
+  IF("${_input_lines}" STREQUAL "")
+    SET(_mpi_count 1 PARENT_SCOPE)
+  ELSE()
+    # go over the (possibly multiple) lines with MPI markers and choose the last
+    FOREACH(_input_line ${_input_lines})
+     SET(_last_line ${_input_line})
+    ENDFOREACH()
+    STRING(REGEX REPLACE "^ *num_smp_ctl *([0-9]+) *$" "\\1"
+           _openmp_count ${_last_line})
+#    MESSAGE( STATUS "MPI_count: " ${_openmp_count} )
+    SET(_mpi_count "${_mpi_count}" PARENT_SCOPE)
+  ENDIF()
+ENDFUNCTION()
+
+ADD_SUBDIRECTORY(Dynamobench_case1)
+ADD_SUBDIRECTORY(Dynamobench_case2)
+ADD_SUBDIRECTORY(heterogineous_temp)

--- a/tests/Dynamobench_case1/CMakeLists.txt
+++ b/tests/Dynamobench_case1/CMakeLists.txt
@@ -1,0 +1,22 @@
+GET_MPI_COUNT("control_MHD")
+GET_OPENMP_COUNT("control_MHD")
+
+configure_file(control_MHD ${CMAKE_BINARY_DIR}/tests/Dynamobench_case1/control_MHD COPYONLY)
+configure_file(control_sph_shell ${CMAKE_BINARY_DIR}/tests/Dynamobench_case1/control_sph_shell COPYONLY)
+
+file(COPY field DESTINATION ${CMAKE_BINARY_DIR}/tests/Dynamobench_case1)
+file(COPY rst_4 DESTINATION ${CMAKE_BINARY_DIR}/tests/Dynamobench_case1)
+file(COPY sph_lm31r48c_4 DESTINATION ${CMAKE_BINARY_DIR}/tests/Dynamobench_case1)
+file(COPY reference DESTINATION ${CMAKE_BINARY_DIR}/tests/Dynamobench_case1)
+
+add_test (NAME "Dynamobench_case1_gen_sph_grids"
+          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/Dynamobench_case1
+          COMMAND mpirun -np ${_mpi_count} ${CMAKE_BINARY_DIR}/bin/gen_sph_grids)
+
+add_test (NAME "Dynamobench_case1_sph_mhd"
+          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/Dynamobench_case1
+          COMMAND mpirun -np ${_mpi_count} ${CMAKE_BINARY_DIR}/bin/sph_mhd)
+
+add_test (NAME "Dynamobench_case1_sph_ene_check"
+          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/Dynamobench_case1
+          COMMAND ${CMAKE_BINARY_DIR}/bin/sph_ene_check)

--- a/tests/Dynamobench_case2/CMakeLists.txt
+++ b/tests/Dynamobench_case2/CMakeLists.txt
@@ -1,0 +1,22 @@
+GET_MPI_COUNT("control_MHD")
+GET_OPENMP_COUNT("control_MHD")
+
+configure_file(control_MHD ${CMAKE_BINARY_DIR}/tests/Dynamobench_case2/control_MHD COPYONLY)
+configure_file(control_sph_shell ${CMAKE_BINARY_DIR}/tests/Dynamobench_case2/control_sph_shell COPYONLY)
+
+file(COPY field DESTINATION ${CMAKE_BINARY_DIR}/tests/Dynamobench_case2)
+file(COPY rst_4 DESTINATION ${CMAKE_BINARY_DIR}/tests/Dynamobench_case2)
+file(COPY sph_lm31r48c_ic_4 DESTINATION ${CMAKE_BINARY_DIR}/tests/Dynamobench_case2)
+file(COPY reference DESTINATION ${CMAKE_BINARY_DIR}/tests/Dynamobench_case2)
+
+add_test (NAME "Dynamobench_case2_gen_sph_grids" 
+          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/Dynamobench_case2
+          COMMAND mpirun -np ${_mpi_count} ${CMAKE_BINARY_DIR}/bin/gen_sph_grids)
+
+add_test (NAME "Dynamobench_case2_sph_mhd" 
+          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/Dynamobench_case2  
+          COMMAND mpirun -np ${_mpi_count} ${CMAKE_BINARY_DIR}/bin/sph_mhd)
+
+add_test (NAME "Dynamobench_case2_sph_ene_check"
+          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/Dynamobench_case2  
+          COMMAND ${CMAKE_BINARY_DIR}/bin/sph_ene_check)

--- a/tests/heterogineous_temp/CMakeLists.txt
+++ b/tests/heterogineous_temp/CMakeLists.txt
@@ -1,0 +1,23 @@
+GET_MPI_COUNT("control_MHD")
+GET_OPENMP_COUNT("control_MHD")
+
+configure_file(control_MHD ${CMAKE_BINARY_DIR}/tests/heterogineous_temp/control_MHD COPYONLY)
+configure_file(control_sph_shell ${CMAKE_BINARY_DIR}/tests/heterogineous_temp/control_sph_shell COPYONLY)
+configure_file(bc_spectr.btx ${CMAKE_BINARY_DIR}/tests/heterogineous_temp/bc_spectr.btx COPYONLY)
+
+file(COPY field DESTINATION ${CMAKE_BINARY_DIR}/tests/heterogineous_temp)
+file(COPY rst_2 DESTINATION ${CMAKE_BINARY_DIR}/tests/heterogineous_temp)
+file(COPY sph_lm4r64c_2 DESTINATION ${CMAKE_BINARY_DIR}/tests/heterogineous_temp)
+file(COPY reference DESTINATION ${CMAKE_BINARY_DIR}/tests/heterogineous_temp)
+
+add_test (NAME "heterogineous_temp_gen_sph_grids" 
+          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/heterogineous_temp  
+          COMMAND mpirun -np ${_mpi_count} ${CMAKE_BINARY_DIR}/bin/gen_sph_grids)
+
+add_test (NAME "heterogineous_temp_sph_mhd" 
+          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/heterogineous_temp  
+          COMMAND mpirun -np ${_mpi_count} ${CMAKE_BINARY_DIR}/bin/sph_mhd)
+
+add_test (NAME "heterogineous_temp_sph_ene_check"
+          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/heterogineous_temp
+          COMMAND ${CMAKE_BINARY_DIR}/bin/sph_ene_check)


### PR DESCRIPTION
I have configured cmake to create the binary sph_ene_check as well as running the following tests:

- Dynamobench_case1
- Dynamobench_case2
- heterogineous_temp

Note that each "test" is further broken into three separate tests:

-  <test_directory_name>_gen_sph_grids
- <test_directory_name>_sph_mhd
- <test_directory_name>_sph_ene_check

In total, there are now 9 tests.