### PR TITLE
Create Dockerfile for buildenv container

### DIFF
--- a/docker/calypso-buildenv-bionic/Dockerfile
+++ b/docker/calypso-buildenv-bionic/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:bionic
+
+RUN apt update && \
+  DEBIAN_FRONTEND='noninteractive' \
+  DEBCONF_NONINTERACTIVE_SEEN='true' \
+  apt install --yes \
+  build-essential \
+  cmake \
+  doxygen \
+  fftw-dev \
+  git \
+  libblas-dev \
+  libhdf5-openmpi-dev \
+  libopenmpi-dev \
+  ninja-build \
+  openmpi-bin \
+  openmpi-common

--- a/docker/calypso-buildenv-bionic/README.md
+++ b/docker/calypso-buildenv-bionic/README.md
@@ -1,0 +1,1 @@
+Build environment for Calypso using the Ubuntu Bionic (18.04) Docker container.


### PR DESCRIPTION
This Dockerfile will be used to create a clean container for building Calypso. Dockerfiles make it easy to be explicit about environment requirements, and containers can also be easily removed after build tests have completed. Having the Dockerfile in the repository makes it simple to update and allows DockerHub to automatically build and distribute the container.

For an example of how this can work, see VirtualQuake: https://github.com/geodynamics/vq/tree/master/docker and VirtualQuakes containers: https://hub.docker.com/u/geodynamics