### PR TITLE
Add cleanWs to post build step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,4 +30,6 @@ pipeline {
       }
     }
   }
+
+  post { always { cleanWs() } }
 }


### PR DESCRIPTION
This tells Jenkins to remove the workspace created in the docker container after completing a build.